### PR TITLE
Make bushido command work on Ruby 1.8.7

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,9 @@
+require 'rake/testtask'
 require 'bundler'
 Bundler::GemHelper.install_tasks
+
+Rake::TestTask.new do |t|
+  t.libs += ["lib", "test"]
+  t.test_files = FileList['test/test*.rb']
+  t.verbose = true
+end

--- a/bin/bushido
+++ b/bin/bushido
@@ -8,7 +8,7 @@ end
 
 options = {}
 
-commands = [:login, :remove_account, :claim,  :list, :create, :show, :start, :stop, :restart, :update, :open, :logs, :add_var, :remove_var, :ssh_key, :api_key].sort
+commands = [:login, :remove_account, :claim,  :list, :create, :show, :start, :stop, :restart, :update, :open, :logs, :add_var, :remove_var, :ssh_key, :api_key].sort_by {|s| s.to_s}
 
 help_docs = {
   :login => "bushido login - Authorizes this machine to work under your Bushido account",

--- a/bin/bushido
+++ b/bin/bushido
@@ -1,5 +1,10 @@
 #!/usr/bin/env ruby
-require 'bushido'
+begin
+  require 'bushido'
+rescue LoadError
+  $: << File.expand_path("../../lib", __FILE__)
+  require 'bushido'
+end
 
 options = {}
 

--- a/test/test_executable.rb
+++ b/test/test_executable.rb
@@ -1,0 +1,10 @@
+require 'test/unit'
+
+class TestExecutable < Test::Unit::TestCase
+  EXECUTABLE = 
+  def test_complains_with_no_args
+    output = %x{#{File.expand_path('../../bin/bushido', __FILE__)}}
+    assert output =~ /See bushido -h for more detailed instructions/
+  end
+end
+


### PR DESCRIPTION
I tend to use Ruby 1.8.7, but the bushido command doesn't work on 1.8. This is easily remedied.

Also, tests!
